### PR TITLE
Spatial coord fix

### DIFF
--- a/R/SpatialExperimentMethods.R
+++ b/R/SpatialExperimentMethods.R
@@ -83,13 +83,10 @@ setReplaceMethod(f="spatialCoords", signature="SpatialExperiment", function(x, v
 
                 for (col in colnames(value))
                 {
-                    colidx <- base::which(colnames(colData(x)) == col)
+                    colidx <- base::which(colnames(int_colData(x)) == col)
                     validx <- base::which(colnames(value) == col)
                     int_colData(x)[cDataIdx, colidx] <- value[,validx]
                 }
-
-                x@int_spcIdx <- base::which(colnames(colData(x)) %in%
-                                                colnames(value))
             }
         }
     } else {

--- a/R/SpatialExperimentMethods.R
+++ b/R/SpatialExperimentMethods.R
@@ -19,7 +19,7 @@ setMethod(f="getCellID", signature="SpatialExperiment", function(x)
 #' @param x A SpatialExperiment class object.
 #'
 #' @return a DataFrame within the spatial coordinates.
-#' 
+#'
 #' @export
 #' @aliases spatialCoords
 #' @examples
@@ -31,7 +31,7 @@ setMethod(f="spatialCoords", signature="SpatialExperiment", function(x)
 })
 
 #' spatialCoords-setter
-#' @description a setter method which sets/replaces the spatial coordinate in a 
+#' @description a setter method which sets/replaces the spatial coordinate in a
 #' SpatialExperiment class object.
 #' @param x a SpatialExperiment class object
 #' @param value a DataFrame with the new spatial coordinates to set.
@@ -46,27 +46,31 @@ setMethod(f="spatialCoords", signature="SpatialExperiment", function(x)
 #'         colnames(fakeFishCoords) <- c("MyCell_ID", "Irrelevant", "x", "y")
 #' spatialCoords(se) <- fakeFishCoords
 #' spatialCoords(se)
-setReplaceMethod(f="spatialCoords", signature="SpatialExperiment", 
-                function(x, value=DataFrame())
+setReplaceMethod(f="spatialCoords", signature="SpatialExperiment", function(x, value=DataFrame())
 {
-    if(is(value, "data.frame")) 
+    if(is(value, "data.frame"))
     {
         value <- DataFrame(value)
     }
+
+    # Ensure that a cell identifier has been named (if not, it'll be "rownames" by default)
     if(x@int_cellID != "rownames")
     {
+        # Ensure that the column names of `value` contain the cell identifier of the SingleCellExperiment
         if(!(x@int_cellID %in% colnames(value)))
         {
             stop(paste0("Spatial coordinates haven't the defined cellColID. ",
                     "Expected: ", x@int_cellID))
         }
+
         dm <- dim(int_colData(x))
-        ## Case of base SingleCellExperiment 
+
+        ## Case of base SingleCellExperiment
         ## (minimal dimensions are #ngenes x 3 with empty values)
-        if(dm[2] == 3) 
+        if(dm[2] == 2)
         {
             int_colData(x) <- cbind(int_colData(x),value)
-            x@int_spcIdx <- base::which(colnames(int_colData(x)) %in% 
+            x@int_spcIdx <- base::which(colnames(int_colData(x)) %in%
                                             colnames(value))
         } else { ## case of already present spatial coordinates
             cDataIdx1 <- which(colnames(value) %in% colnames(int_colData(x)))
@@ -74,26 +78,30 @@ setReplaceMethod(f="spatialCoords", signature="SpatialExperiment",
             {
                 stop("Spatial coordinates colnames differ from the stored ones")
             } else {
-                cDataIdx <- match(value[[x@int_cellID]], 
-                                int_colData(x)[[x@int_cellID]])
+                cDataIdx <- match(value[[x@int_cellID]],
+                                colData(x)[[x@int_cellID]])
+
                 for (col in colnames(value))
                 {
-                    colidx <- base::which(colnames(int_colData(x)) == col)
+                    colidx <- base::which(colnames(colData(x)) == col)
                     validx <- base::which(colnames(value) == col)
                     int_colData(x)[cDataIdx, colidx] <- value[,validx]
                 }
+
+                x@int_spcIdx <- base::which(colnames(colData(x)) %in%
+                                                colnames(value))
             }
         }
     } else {
         stop("Please specify a different identifier")
     }
-    
+
     return(x)
 })
 
 
 #' spatialCoordsNames-getter
-#' @description getter method for the spatial coordinates names in a 
+#' @description getter method for the spatial coordinates names in a
 #' SpatialExperiment class object.
 #' @param x a SpatialExperiment class object.
 #'


### PR DESCRIPTION
Fixed a bug on line 70 of `R/SpatialExperimentMethods.R`. Changes `if (dm[2] == 3)` to `if (dm[2] == 2)`. By default,
`int_colData(x)` will have only *2* columns, so this would indicate no spatial data having been added yet. Closes #1 