### PR TITLE
VisiumExperiment - minor updates

### DIFF
--- a/R/Miscellaneous.R
+++ b/R/Miscellaneous.R
@@ -1,6 +1,6 @@
 .se_show <- function(object) {
     callNextMethod()
-    coolcat("spatialCoordinates(%d): %s\n", spatialCoordsNames(object))
+    coolcat("spatialCoords(%d): %s\n", spatialCoordsNames(object))
 }
 
 #' SpatialExperiment show method

--- a/vignettes/MouseCoronalVisiumAnalysis.Rmd
+++ b/vignettes/MouseCoronalVisiumAnalysis.Rmd
@@ -70,6 +70,9 @@ countsFile <- system.file(file.path("extdata", "10x_visium",
                             "matrix.mtx"), package="SpatialExperiment")
 countsEx <- readMM(file=countsFile)
 
+# update column names
+colnames(featuresEx) <- c("gene_id", "gene_name", "feature_type")
+colnames(barcodesEx) <- c("barcode")
 ```
 
 ## Spatial Coordinates
@@ -85,6 +88,9 @@ tissPosEx <- read.csv(posFile,
                         col.names=c("Cell_ID", "in_tissue", 
                                     "array_row", "array_col",
                                     "pxl_col_in_fullres", "pxl_row_in_fullres"))
+
+# update column names
+colnames(tissPosEx)[1] <- "barcode"
 ```
 
 

--- a/vignettes/MouseCoronalVisiumAnalysis.Rmd
+++ b/vignettes/MouseCoronalVisiumAnalysis.Rmd
@@ -85,12 +85,9 @@ posFile <- system.file(file.path("extdata", "10x_visium",
                         package="SpatialExperiment")
 tissPosEx <- read.csv(posFile, 
                         sep="\t", header=FALSE, 
-                        col.names=c("Cell_ID", "in_tissue", 
+                        col.names=c("barcode_id", "in_tissue", 
                                     "array_row", "array_col",
                                     "pxl_col_in_fullres", "pxl_row_in_fullres"))
-
-# update column names
-colnames(tissPosEx)[1] <- "barcode_id"
 ```
 
 

--- a/vignettes/MouseCoronalVisiumAnalysis.Rmd
+++ b/vignettes/MouseCoronalVisiumAnalysis.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "10x-Visum Spatial Data Analysis"
+title: "10x-Visium Spatial Data Analysis"
 author: "Dario Righelli"
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 output: 
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(echo = TRUE)
 The SpatialExperiment package provides classes and methods for single cell 
 spatial data handling.
 
-The VisiumExperiment class exteds the SpatialExperiment class
+The VisiumExperiment class extends the SpatialExperiment class
 by providing more specific attributes and methods for the 10x-Genomics Visium
 experiments data.
 
@@ -77,7 +77,7 @@ colnames(barcodesEx) <- c("barcode")
 
 ## Spatial Coordinates
 
-Loading Spatial coordinates of the tissue section.
+Loading spatial coordinates of the tissue section.
 
 ```{r}
 posFile <- system.file(file.path("extdata", "10x_visium",

--- a/vignettes/MouseCoronalVisiumAnalysis.Rmd
+++ b/vignettes/MouseCoronalVisiumAnalysis.Rmd
@@ -72,7 +72,7 @@ countsEx <- readMM(file=countsFile)
 
 # update column names
 colnames(featuresEx) <- c("gene_id", "gene_name", "feature_type")
-colnames(barcodesEx) <- c("barcode")
+colnames(barcodesEx) <- c("barcode_id")
 ```
 
 ## Spatial Coordinates
@@ -90,7 +90,7 @@ tissPosEx <- read.csv(posFile,
                                     "pxl_col_in_fullres", "pxl_row_in_fullres"))
 
 # update column names
-colnames(tissPosEx)[1] <- "barcode"
+colnames(tissPosEx)[1] <- "barcode_id"
 ```
 
 


### PR DESCRIPTION
Hi @drighelli , I have been re-formatting some of my objects into the VisiumExperiment class, and this looks very useful for us.

I have a few minor suggestions in this pull request. Please let me know what you think.

- In the show method, display as `spatialCoords` instead of `spatialCoordinates` so it is consistent with the getter/setter names, which will make things easier for newcomers who find the getter/setter names by displaying the object.

- In the example object in the VisiumExperiment vignette, change the column names of barcodes to `barcode_id` (instead of `Cell_ID`), and column names of features to `gene_id`, `gene_name`, `feature_type`. I think this will make things simpler for people by using more standard names - especially for `barcode_id`, since we have barcodes instead of cells.

- Few minor typos in vignette.

I will keep updating my objects to use VisiumExperiment instead of SingleCellExperiment in the meantime, so may have some more suggestions later. Thanks again for creating this.