### PR TITLE
Visium - simplify column names

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -134,7 +134,7 @@ setClass("VisiumExperiment",
 #'                         sep="\t", header=FALSE,
 #'                         col.names=c("Barcodes", "in_tissue",
 #'                          "array_row", "array_col",
-#'                          "pxl_col_in_fullres", "pxl_row_in_fullres"))
+#'                          "pxl_col_fullres", "pxl_row_fullres"))
 #' scaleFile <- system.file(file.path("extdata", "10x_visium",
 #'                                    "scalefactors_json.json"), 
 #'                          package="SpatialExperiment")

--- a/R/Validity.R
+++ b/R/Validity.R
@@ -15,12 +15,12 @@ setValidity2("SpatialExperiment", .spe_validity)
 {
     msg <- NULL
     if( sum(c("in_tissue", "array_row", "array_col",
-            "pxl_col_in_fullres", "pxl_row_in_fullres")
+            "pxl_col_fullres", "pxl_row_fullres")
             %in% colnames(spatialCoords(object))) != 5 ) 
     {
         msg <- c(msg, paste0("Please use the 10x Visium colnames for the",
             " spatial coordinates. (Defaults are 'in_tissue, 'array_row'", 
-            " 'array_col', 'pxl_col_in_fullres', 'pxl_row_in_fullres')"))
+            " 'array_col', 'pxl_col_fullres', 'pxl_row_fullres')"))
     }
     
     if( sum(c("spot_diameter_fullres", "tissue_hires_scalef",

--- a/man/VisiumExperiment.Rd
+++ b/man/VisiumExperiment.Rd
@@ -58,7 +58,7 @@ tissPosEx <- read.csv(posFile,
                         sep="\t", header=FALSE,
                         col.names=c("Barcodes", "in_tissue",
                          "array_row", "array_col",
-                         "pxl_col_in_fullres", "pxl_row_in_fullres"))
+                         "pxl_col_fullres", "pxl_row_fullres"))
 scaleFile <- system.file(file.path("extdata", "10x_visium",
                                    "scalefactors_json.json"), 
                          package="SpatialExperiment")


### PR DESCRIPTION
This one is a very minor suggestion - in the interests of making column names as short as possible, I suggest changing `pxl_col_in_fullres` and `pxl_row_in_fullres` to `pxl_col_fullres` and `pxl_row_fullres`. Having slightly shorter column names makes it a little bit easier to display the `spatialCoords` data frame in the console, since the columns are narrower.

(However feel free to ignore if you prefer the original names, or if they have been chosen for a specific reason, e.g. to match definitions in 10x Genomics raw data files.)