### PR TITLE
add arg to read in fil/raw data; default to lowres img

### DIFF
--- a/R/read10xVisium.R
+++ b/R/read10xVisium.R
@@ -14,7 +14,10 @@
 #' @param type character string specifying 
 #'   the type of format to read count data from
 #'   (see \code{\link{read10xCounts}})
+#' @param data character string specifying whether to read in
+#'   filtered (spots mapped to tissue) or raw data (all spots).
 #' @param images character vector specifying which images to include.
+#'   Valid values are "lowres", "hires", "detected", "aligned", "fullres".
 #' @param load logical; should the image(s) be loaded into memory
 #'   as a \code{grob}? If FALSE, will store the path/URL instead.
 #'   
@@ -70,11 +73,11 @@
 #' @export
 read10xVisium <- function(samples="",
     sample_id=paste0("sample", seq_along(samples)),
-    type=c("HDF5", "sparse"),
-    images=c("fullres", "lowres", "hires", "detected", "aligned"),
-    load=TRUE)
+    type=c("HDF5", "sparse"), data=c("filtered", "raw"),
+    images="lowres", load=TRUE)
 {
     type <- match.arg(type)
+    data <- match.arg(data)
     imgs <- match.arg(images, several.ok=TRUE)
 
     # check sample identifiers
@@ -90,7 +93,7 @@ read10xVisium <- function(samples="",
     
     # setup file paths
     fn <- paste0(
-        "raw_feature_bc_matrix", 
+        paste0(data, "_feature_bc_matrix"), 
         switch(type, HDF5=".h5", ""))
     counts <- file.path(samples, fn)
     

--- a/man/read10xVisium.Rd
+++ b/man/read10xVisium.Rd
@@ -8,7 +8,8 @@ read10xVisium(
   samples = "",
   sample_id = paste0("sample", seq_along(samples)),
   type = c("HDF5", "sparse"),
-  images = c("fullres", "lowres", "hires", "detected", "aligned"),
+  data = c("filtered", "raw"),
+  images = "lowres",
   load = TRUE
 )
 }
@@ -25,7 +26,11 @@ ignored if \code{!is.null(names(samples))}}
 the type of format to read count data from
 (see \code{\link{read10xCounts}})}
 
-\item{images}{character vector specifying which images to include.}
+\item{data}{character string specifying whether to read in
+filtered (spots mapped to tissue) or raw data (all spots).}
+
+\item{images}{character vector specifying which images to include.
+Valid values are "lowres", "hires", "detected", "aligned", "fullres".}
 
 \item{load}{logical; should the image(s) be loaded into memory
 as a \code{grob}? If FALSE, will store the path/URL instead.}


### PR DESCRIPTION
- added argument `data = c("filtered", "raw")` to give the option whether to read in filtered (spots mapped to tissue) or raw data (all spots)
- modified default `images = "lowres"` as the previous design (`match.arg(images, several.ok = TRUE)`) i) read in all images and ii) failed if any images were missing. The list of valid choices for `images` are instead provided in the documentation.