### PR TITLE
Unittests

### DIFF
--- a/R/SpatialExperiment.R
+++ b/R/SpatialExperiment.R
@@ -224,6 +224,8 @@ SpatialExperiment <- function(...,
                 imageSource=imageSources[i], scaleFactor=scaleFactor, 
                 sample_id=sample_id[i], image_id=image_id[i], load=loadImage)
         }
+    } else {
+        imgData(spe) <- NULL
     }
     return(spe)
 }

--- a/R/Validity.R
+++ b/R/Validity.R
@@ -69,7 +69,7 @@
         return(msg)
     
     nms <- c("sample_id", "image_id", "data", "scaleFactor")
-    if (!all(nms %in% names(df)))
+    if (!identical(nms, names(df)))
         msg <- c(msg, paste(
             "'imgData' field in 'int_metadata' should have columns:",
             paste(sQuote(nms), collapse = ", ")))

--- a/R/imgData.R
+++ b/R/imgData.R
@@ -10,19 +10,21 @@ setMethod("imgData", "SpatialExperiment", function(x) int_metadata(x)$imgData)
 setReplaceMethod("imgData",
     c("SpatialExperiment", "DataFrame"),
     function(x, value) {
-        msg <- .imgData_validity(value)
-        if (!is.null(msg))
-            stop(msg)
+        if (!isEmpty(value)) {
+            msg <- .imgData_validity(value)
+            if (!is.null(msg))
+                stop(msg)
+        }
         int_metadata(x)$imgData <- value
         return(x)
     })
 
 #' @rdname SpatialExperiment-methods
-#' @importFrom SingleCellExperiment int_metadata<-
+#' @importFrom S4Vectors DataFrame
 #' @export
 setReplaceMethod("imgData",
     c("SpatialExperiment", "NULL"),
     function(x, value) {
-        int_metadata(x)$imgData <- value
-        return(x)
+        value <- DataFrame()
+        `imgData<-`(x, value)
     })

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,4 +1,4 @@
-changes in version 1.1.6 (2021-01-04)
+changes in version 1.1.6 (2021-02-04)
 + removed additional slots in the SPE class definition 
   (i.e. spatialData and spatialCoordsNames)
 + spatialCoords stored in int_colData() = numeric matrix
@@ -13,6 +13,10 @@ changes in version 1.1.6 (2021-01-04)
   which are made unique with a message
 + consistent usage of "spe" for SpatialExperiment objects across 
   all examples (previously, both ve and se were used as well)
++ fixed cache/path-related error on windows in SpatialImage unit tests
++ added unit-tests of SpatialExperiment class validity
++ imgData field in int_metadata is now required 
+  to exist (but can be an empty DFrame)
 
 changes in version 1.1.5 (2021-31-03)
 + version bump to x.y.z format with .z increment

--- a/tests/testthat/test_SpatialExperiment-validity.R
+++ b/tests/testthat/test_SpatialExperiment-validity.R
@@ -1,0 +1,93 @@
+# note that, in order to enforce invalid replacements,
+# the tests below purposefully use
+#   @colData<- instead of colData<-
+#   in_metadata$imgData<- instead of imgData<-
+#   int_colData$spatialCoords <- instead of spatialCoords<-
+#   int_metadata$spatialDataNames instead of spatialDataNames<-
+
+test_that("colData", {
+    # initialize mock SPE
+    img <- system.file(
+        "extdata", "10xVisium", "section1", "spatial", 
+        "tissue_lowres_image.png", package="SpatialExperiment")
+    spe <- SpatialExperiment(
+        assays=diag(n <- 10),
+        colData=DataFrame(a=seq(n)),
+        sample_id="foo")
+    spe <- addImg(spe, 
+        imageSource=img, 
+        scaleFactor=1, 
+        sample_id="foo",
+        image_id="foo",
+        load=FALSE)
+    # complete removal of colData
+    tmp <- spe
+    tmp@colData <- make_zero_col_DFrame(n)
+    expect_error(validObject(tmp))
+    # removal of sample_ids
+    tmp <- spe
+    tmp@colData$sample_id <- NULL
+    expect_error(validObject(tmp))
+    # 
+    # mismatch with sample_id in imgData
+    tmp <- spe
+    tmp@colData$sample_id <- "x"
+    expect_error(validObject(tmp))
+})
+
+test_that("spatialCoords", {
+    # initialize mock SPE
+    spe <- SpatialExperiment(
+        assays=diag(n <- 10))
+    # invalid replacements
+    foo <- list(
+        NULL,
+        rep(1, n),
+        rep("", n),
+        factor(seq(n)),
+        matrix("", n, 2),
+        data.frame(seq(n)),
+        DataFrame(seq(n)))
+    for (. in foo) {
+        int_colData(spe)$spatialCoords <- .
+        expect_error(validObject(spe)) 
+    }
+    # valid replacements
+    foo <- list(
+        matrix(1, n),
+        matrix(1, n, 2),
+        matrix(NA_real_, n),
+        matrix(NA_integer_, n))
+    for (. in foo) {
+        int_colData(spe)$spatialCoords <- .
+        expect_true(validObject(spe)) 
+    }
+})
+
+test_that("SpatialDataNames", {
+    # initialize mock SPE
+    spe <- SpatialExperiment(
+        assays=diag(n <- 10),
+        colData=DataFrame(a=seq(n), b=seq(n)))
+    # invalid replacements
+    foo <- list(NULL, NA, 1, "c", c("a", "c"), c(NA, "c"))
+    for (. in foo) {
+        int_metadata(spe)$spatialDataNames <- .
+        expect_error(validObject(spe)) 
+    }
+    # valid replacements
+    foo <- list(character(), "a", "b", c("a", "b"))
+    for (. in foo) {
+        int_metadata(spe)$spatialDataNames <- .
+        expect_true(validObject(spe)) 
+    }
+})
+
+test_that("imgData", {
+    # initialize mock SPE
+    spe <- SpatialExperiment(
+        assays=diag(n <- 10))
+    # complete removal of imgData
+    int_metadata(spe)$imgData <- NULL
+    expect_error(validObject(spe))
+})

--- a/tests/testthat/test_SpatialExperiment.R
+++ b/tests/testthat/test_SpatialExperiment.R
@@ -2,10 +2,11 @@ example(read10xVisium, echo = FALSE)
 
 test_that("empty constructor", {
     spe <- SpatialExperiment()
-    expect_null(imgData(spe))
+    expect_is(imgData(spe), "DFrame")
+    expect_true(isEmpty(imgData(spe)))
     expect_identical(spatialDataNames(spe), character())
-    expect_is( spatialData(spe), "DFrame")
-    expect_true(isEmpty( spatialData(spe)))
+    expect_is(spatialData(spe), "DFrame")
+    expect_true(isEmpty(spatialData(spe)))
     expect_equal(dim(spatialData(spe)), c(ncol(spe), 0))
     expect_null(spatialCoordsNames(spe))
     expect_is(spatialCoords(spe), "matrix")
@@ -116,7 +117,9 @@ test_that(".sce_to_spe()", {
         colData=cd)
     spe <- .sce_to_spe(sce)
     expect_is(spe, "SpatialExperiment")
-    expect_null(imgData(spe))
+    expect_is(imgData(spe), "DFrame")
+    expect_true(isEmpty(imgData(spe)))
+    expect_is(spatialData(spe), "DFrame")
     expect_true(isEmpty(spatialData(spe)))
     expect_identical(colData(spe), colData(sce))
     
@@ -140,3 +143,4 @@ test_that("scaleFactors should be numeric, a named list or JSON file", {
     expect_silent(.sce_to_spe(sce, imageSources=img_fn, 
         scaleFactors=list(tissue_lowres_scalef=1)))
 })
+


### PR DESCRIPTION
+ added "fixed cache/path-related error on windows in SpatialImage unit tests" to NEWS file
+ added unit-tests of SpatialExperiment class validity
+ imgData field in int_metadata is now required to exist (but can be an empty DFrame)
+ bug fix in spatialCoords validity check (missing parentheses in logical statement)
+ removed redundant (unused) code in SpatialExperiment validity