### PR TITLE
Col data replacement

### DIFF
--- a/R/SpatialExperiment-colData.R
+++ b/R/SpatialExperiment-colData.R
@@ -39,32 +39,48 @@ setReplaceMethod("colData",
         colData(se) <- value
         new <- colData(se)
         
-        # check that 'sample_id's remain valid & update 'imgData' accordingly
-        ns_old <- length(sids_old <- unique(old$sample_id))
-        ns_new <- length(sids_new <- unique(new$sample_id))
-        if (ns_old != ns_new) {
-            warning(sprintf(
-                "Number of unique 'sample_id's is %s, but %s %s provided.\n",
-                ns_old, ns_new, ifelse(ns_new > 1, "were", "was")))
-        } else if (sum(table(old$sample_id, new$sample_id) != 0) != ns_old) {
-            warning("New 'sample_id's must map uniquely")
-        } else if (!is.null(imgData(x))) {
-            m <- match(imgData(x)$sample_id, sids_old)
-            imgData(x)$sample_id <- sids_new[m]
+        if (!is.null(new$sample_id)) {
+            # check that 'sample_id's remain valid & update 'imgData' accordingly
+            ns_old <- length(sids_old <- unique(old$sample_id))
+            ns_new <- length(sids_new <- unique(new$sample_id))
+            if (ns_old != ns_new) {
+                stop(sprintf(
+                    "Number of unique 'sample_id's is %s, but %s %s provided.\n",
+                    ns_old, ns_new, ifelse(ns_new > 1, "were", "was")))
+            } else if (sum(table(old$sample_id, new$sample_id) != 0) != ns_old) {
+                stop("New 'sample_id's must map uniquely")
+            } else if (!is.null(imgData(x))) {
+                m <- match(imgData(x)$sample_id, sids_old)
+                imgData(x)$sample_id <- sids_new[m]
+            }    
+        } else {
+            # if none provided, retain original sample_id field
+            value$sample_id <- old$sample_id
         }
+
+        # protect spatialData from being replaced
+        spd <- spatialData(x, 
+            spatialCoords=FALSE, 
+            colData=FALSE)
+        value <- cbind(value, spd)
         BiocGenerics:::replaceSlots(x, colData=value, check=FALSE)
     }
 )
 
 #' @rdname SpatialExperiment-colData
-#' @importFrom S4Vectors DataFrame
 #' @importFrom SummarizedExperiment colData colData<-
 #' @export
 setReplaceMethod("colData",
     c("SpatialExperiment", "NULL"),
     function(x, value) {
-        warning("Dropping colData could break",
-            " imgData and spatialData functionality.")
-        BiocGenerics:::replaceSlots(x, colData=value, check=FALSE)
+        # replacement by NULL keeps 
+        # sample_id & spatialDataNames
+        ids <- colData(x)["sample_id"]
+        spd <- spatialData(x, 
+            spatialCoords=FALSE, 
+            colData=FALSE)
+        value <- cbind(ids, spd)
+        colData(x) <- value
+        return(x)
     }
 )

--- a/R/SpatialExperiment-methods.R
+++ b/R/SpatialExperiment-methods.R
@@ -175,8 +175,10 @@ setReplaceMethod("spatialData",
 setReplaceMethod("spatialData", 
     c("SpatialExperiment", "NULL"),
     function(x, value) {
+        # @<- is required here to enforce replacement because
+        # spatialDataNames are protected during colData replacement
         i <- spatialDataNames(x)
-        colData(x)[i] <- NULL
+        x@colData[i] <- NULL
         spatialDataNames(x) <- NULL
         return(x)
     }

--- a/R/SpatialExperiment.R
+++ b/R/SpatialExperiment.R
@@ -191,7 +191,7 @@ SpatialExperiment <- function(...,
     } else {
         spatialCoords(spe) <- NULL
     }
-    
+
     if (!is.null(spatialDataNames)) {
         stopifnot(
             is.character(spatialDataNames), 
@@ -203,7 +203,8 @@ SpatialExperiment <- function(...,
         stopifnot(
             is(spatialData, "DFrame"),
             nrow(spatialData) == ncol(spe))
-        spatialData(spe) <- spatialData
+        colData(spe) <- cbind(colData(spe), spatialData)
+        spatialDataNames(spe) <- names(spatialData)
     } else {
         spatialData(spe) <- NULL
     }

--- a/R/read10xVisium.R
+++ b/R/read10xVisium.R
@@ -56,7 +56,7 @@
 #' file.path(samples[1], "raw_feature_bc_matrix")
 #' 
 #' (spe <- read10xVisium(samples, sample_ids, 
-#'   type="sparse", data="raw", 
+#'   type = "sparse", data = "raw", 
 #'   images = "lowres", load = FALSE))
 #' 
 #' # tabulate number of spots mapped to tissue
@@ -125,7 +125,7 @@ read10xVisium <- function(samples="",
     nan <- !file.exists(img_fns)
     if (all(nan)) {
         stop(sprintf(
-            "No matching files found for 'images = c(%s)", 
+            "No matching files found for 'images=c(%s)", 
             paste(dQuote(imgs), collapse=", ")))
     } else if (any(nan)) {
         message("Skipping missing images\n  ", 
@@ -146,11 +146,11 @@ read10xVisium <- function(samples="",
         spd <- .read_xyz(xyz[i])
         sce <- sce[, rownames(spd)]
         SpatialExperiment(
-            assays = assays(sce),
-            rowData = DataFrame(symbol = rowData(sce)$Symbol),
-            sample_id = sids[i],
-            spatialData = DataFrame(spd),
-            spatialCoordsNames = c("pxl_col_in_fullres", "pxl_row_in_fullres"))
+            assays=assays(sce),
+            rowData=DataFrame(symbol=rowData(sce)$Symbol),
+            sample_id=sids[i],
+            spatialData=DataFrame(spd),
+            spatialCoordsNames=c("pxl_col_in_fullres", "pxl_row_in_fullres"))
     }) 
     spe <- do.call(cbind, spel)
     imgData(spe) <- img
@@ -166,7 +166,7 @@ read10xVisium <- function(samples="",
     df <- lapply(seq_along(x), function(i) 
     {
         df <- read.csv(x[i], header=FALSE, row.names=1, col.names=cnms)
-        if (length(x) > 1) rownames(df) <- paste(i, rownames(df), sep = "_")
+        if (length(x) > 1) rownames(df) <- paste(i, rownames(df), sep="_")
         if (!is.null(names(x))) cbind(sample_id=names(x)[i], df)
         df
     })

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -17,6 +17,8 @@ changes in version 1.1.6 (2021-02-04)
 + added unit-tests of SpatialExperiment class validity
 + imgData field in int_metadata is now required 
   to exist (but can be an empty DFrame)
++ colData<- protects sample_id & spatialDataNames 
+  fields; spatialData<- protects colData
 
 changes in version 1.1.5 (2021-31-03)
 + version bump to x.y.z format with .z increment

--- a/man/read10xVisium.Rd
+++ b/man/read10xVisium.Rd
@@ -72,7 +72,7 @@ list.files(file.path(samples[1], "spatial"))
 file.path(samples[1], "raw_feature_bc_matrix")
 
 (spe <- read10xVisium(samples, sample_ids, 
-  type="sparse", data="raw", 
+  type = "sparse", data = "raw", 
   images = "lowres", load = FALSE))
 
 # tabulate number of spots mapped to tissue

--- a/tests/testthat/test_SpatialExperiment-cbind.R
+++ b/tests/testthat/test_SpatialExperiment-cbind.R
@@ -1,0 +1,35 @@
+example(read10xVisium, echo = FALSE)
+
+test_that("duplicated sample_ids are made unique with a message", {
+    expect_message(new <- cbind(spe, spe))
+    expect_equal(
+        length(unique(new$sample_id)), 
+        2*length(unique(spe$sample_id)))
+    expect_true(nrow(new) == nrow(spe))
+    expect_true(ncol(new) == 2*ncol(spe))
+    expect_identical(rownames(new), rownames(spe))
+    expect_setequal(colnames(new), colnames(spe))
+})
+
+test_that("imgData are combined correctly", {
+    spe1 <- spe; spe2 <- spe
+    spe1$sample_id <- paste(spe1$sample_id, "A", sep=".")
+    spe2$sample_id <- paste(spe2$sample_id, "B", sep=".")
+    expect_silent(spe3 <- cbind(spe1, spe2))
+    # imgData are kept only once
+    expect_true(sum(grepl("imgData", names(int_metadata(spe3)))) == 1)
+    # number of image entries should be doubled
+    expect_equal(nrow(imgData(spe3)), 2*nrow(imgData(spe)))
+    # sample_ids should be combined from input SPEs
+    expect_setequal(
+        unique(spe3$sample_id), 
+        imgData(spe3)$sample_id)
+    expect_setequal(
+        unique(spe3$sample_id), 
+        unique(c(spe1$sample_id, spe2$sample_id)))
+    # imgData from each input SPE should be the same
+    one <- seq(nrow(imgData(spe1)))
+    two <- max(one)+seq(nrow(imgData(spe2)))
+    expect_identical(imgData(spe3)[one, ], imgData(spe1))
+    expect_identical(imgData(spe3)[two, ], imgData(spe2))
+})

--- a/tests/testthat/test_SpatialExperiment-colData.R
+++ b/tests/testthat/test_SpatialExperiment-colData.R
@@ -1,15 +1,40 @@
 example(read10xVisium, echo = FALSE)
 
-test_that("colData()<-NULL throws warning", {
-    expect_warning(colData(spe) <- NULL)
+test_that("colData()<-NULL retains only sample_id & spatialDataNames fields", {
+    tmp <- spe
+    tmp$foo <- "foo"
+    colData(tmp) <- NULL
+    expect_null(tmp$foo)
+    expect_identical(tmp$sample_id, spe$sample_id)
+    expect_identical(spatialData(tmp), spatialData(spe))
 })
 
-test_that("x$sample_id<- needs one-to-one mapping", {
-    expect_warning(spe$sample_id <- NULL)
-    expect_warning(spe$sample_id <- sample(c(1, 2), ncol(spe), TRUE))
+test_that(paste(
+    "valid colData<- without sample_id field", 
+    "protects sample_id & spatialDataNames fields"), {
+    tmp <- spe
+    tmp$foo <- "foo"
+    colData(tmp) <- DataFrame(x=seq(ncol(tmp)))
+    expect_null(tmp$foo)
+    expect_identical(tmp$sample_id, spe$sample_id)
+    expect_equivalent(spatialData(tmp), spatialData(spe))
 })
 
-test_that("valid x$sample_id replacement updates imgData", {
+test_that("colData<- with valid sample_id field passes", {
+    old <- unique(spe$sample_id)
+    new <- letters[seq_along(old)]
+    new <- new[match(spe$sample_id, old)]
+    cd <- DataFrame(sample_id=new)
+    expect_silent(colData(spe) <- cd)
+})
+
+test_that("sample_id<- needs one-to-one mapping", {
+    new <- spe$sample_id; new[1] <- "foo"
+    expect_error(spe$sample_id <- new)
+    expect_error(spe$sample_id <- sample(spe$sample_id))
+})
+
+test_that("valid sample_id<- updates imgData", {
     old <- unique(spe$sample_id)
     new <- paste0(old, "x")
     i <- match(spe$sample_id, old)

--- a/tests/testthat/test_SpatialExperiment-subset.R
+++ b/tests/testthat/test_SpatialExperiment-subset.R
@@ -1,5 +1,11 @@
 example(read10xVisium, echo = FALSE)
 
+test_that("missing i/j retains all", {
+    expect_identical(spe, spe[, ])
+    expect_identical(spe, spe[TRUE, ])
+    expect_identical(spe, spe[, TRUE])
+})
+
 test_that("i=TRUE,j=TRUE retains all data", {
     expect_identical(spe, spe[TRUE, TRUE])
 })

--- a/tests/testthat/test_SpatialExperiment-validity.R
+++ b/tests/testthat/test_SpatialExperiment-validity.R
@@ -28,7 +28,6 @@ test_that("colData", {
     tmp <- spe
     tmp@colData$sample_id <- NULL
     expect_error(validObject(tmp))
-    # 
     # mismatch with sample_id in imgData
     tmp <- spe
     tmp@colData$sample_id <- "x"


### PR DESCRIPTION
- added unit-tests for `colData<-`
- `colData<-` protects `sample_id` & `spatialDataNames`
  - replacement by NULL silently keeps these fields 
  - replacement of `sample_id`s required one-to-one mapping and is `stop()`ped otherwise
  - valid replacement updates the `sample_id` field in `imgData`
- `spatialData<-` protects `colData`
  - replacement by NULL drops only `spatialDataNames` fields
  - valid replacement updates the `spatialDataNames` field in `int_metadata`