### PR TITLE
bug fix to assure reordering of counts/spatialData always works

### DIFF
--- a/R/read10xVisium.R
+++ b/R/read10xVisium.R
@@ -141,10 +141,15 @@ read10xVisium <- function(samples="",
             samples=counts[i], 
             sample.names=sids[i],
             col.names=TRUE)
-
-        # construct 'SpatialExperiment'
+        # read in spatial data
         spd <- .read_xyz(xyz[i])
-        sce <- sce[, rownames(spd)]
+        # match ordering
+        obs <- intersect(
+            colnames(sce), 
+            rownames(spd))
+        sce <- sce[, obs]
+        spd <- spd[obs, ]
+        # construct 'SpatialExperiment'
         SpatialExperiment(
             assays=assays(sce),
             rowData=DataFrame(symbol=rowData(sce)$Symbol),


### PR DESCRIPTION
Previously, reordering wasn't robust depending on whether there are more counts or spatial data... The corresponding code chunk in `read10xVisium()` now assures this always works:

```
        # read count data as 'SingleCellExperiment'
        sce <- read10xCounts(
            samples=counts[i], 
            sample.names=sids[i],
            col.names=TRUE)
        # read in spatial data
        spd <- .read_xyz(xyz[i])
        # match ordering
        obs <- intersect(
            colnames(sce), 
            rownames(spd))
        sce <- sce[, obs]
        spd <- spd[obs, ]
``` 