### PR TITLE
avoid duplication of spatialCoords when constructing SPE from colData

### DIFF
--- a/.github/workflows/R-cmd-check.yaml
+++ b/.github/workflows/R-cmd-check.yaml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: windows-latest, r: 'devel', bioc: 'devel'}
-        #
+        #- { os: windows-latest, r: 'devel', bioc: 'devel'}
+        - { os: windows-latest, r: 'release', bioc: 'devel'}
         - { os: macOS-latest, r: 'devel', bioc: 'devel'}
         #
         - { os: ubuntu-latest, r: 'devel', image: 'bioconductor/bioconductor_docker:devel'}

--- a/.github/workflows/R-cmd-check.yaml
+++ b/.github/workflows/R-cmd-check.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         config:
         #- { os: windows-latest, r: 'devel', bioc: 'devel'}
-        - { os: windows-latest, r: 'release', bioc: 'devel'}
+        - { os: windows-latest, r: '4.1', bioc: 'devel'}
         - { os: macOS-latest, r: 'devel', bioc: 'devel'}
         #
         - { os: ubuntu-latest, r: 'devel', image: 'bioconductor/bioconductor_docker:devel'}

--- a/.github/workflows/R-cmd-check.yaml
+++ b/.github/workflows/R-cmd-check.yaml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        #- { os: windows-latest, r: 'devel', bioc: 'devel'}
-        - { os: windows-latest, r: '4.1', bioc: 'devel'}
+        - { os: windows-latest, r: 'devel', bioc: 'devel'}
+        #- { os: windows-latest, r: '4.1', bioc: 'devel'}
         - { os: macOS-latest, r: 'devel', bioc: 'devel'}
         #
         - { os: ubuntu-latest, r: 'devel', image: 'bioconductor/bioconductor_docker:devel'}

--- a/R/SpatialExperiment.R
+++ b/R/SpatialExperiment.R
@@ -175,7 +175,10 @@ SpatialExperiment <- function(...,
         if (!is.null(spatialCoords)) 
             msg("spatialCoords")
         if (all(spatialCoordsNames %in% names(colData(spe)))) {
-            spatialCoords(spe) <- as.matrix(colData(spe)[spatialCoordsNames])
+            i <- spatialCoordsNames
+            j <- setdiff(names(colData(spe)), i)
+            spatialCoords(spe) <- as.matrix(colData(spe)[i])
+            colData(spe) <- colData(spe)[j]
         } else {
             i <- spatialCoordsNames
             j <- setdiff(names(spatialData), i)

--- a/tests/testthat/test_SpatialExperiment.R
+++ b/tests/testthat/test_SpatialExperiment.R
@@ -27,6 +27,17 @@ test_that("spatialDataNames = character in colData", {
     expect_identical(spatialData(spe), cd)
 })
 
+test_that("spatialData/CoordsNames = character in colData", {
+    cd <- DataFrame(x=numeric(), y=numeric(), z=numeric())
+    spe <- SpatialExperiment(
+        colData=cd, 
+        spatialDataNames="z",
+        spatialCoordsNames=c("x", "y"))
+    expect_identical(spatialDataNames(spe), "z")
+    expect_identical(spatialCoordsNames(spe), c("x", "y"))
+    expect_true(!any(c("x", "y") %in% names(colData(spe))))
+})
+
 test_that("spatialCoords = numeric matrix", {
     y <- diag(n <- 10)
     mat <- matrix(0, n, m <- 2)


### PR DESCRIPTION
- modified `SpatialExperiment` constructor when `colData` is `DFrame` and `spatialData/CoordsNames` are character
  - previously, `spatialCoords` were retained in the `colData`, and also stored in `int_colData` (-> duplication)
  - now, `spatialCoords` are removed from `colData`, and only stored separately 
- added unit test in `test_SpatialExperiment.R` to check this is really happening