### PR TITLE
v1.1.701 -- solve winOS issue #64

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SpatialExperiment
 Type: Package
 Title: S4 Class for Spatial Experiments handling 
-Version: 1.1.700
-Date: 2021-05-05
+Version: 1.1.701
+Date: 2021-05-07
 Authors@R: c(
     person("Dario", "Righelli", role=c("aut", "cre"), 
         email="dario.righelli@gmail.com"),

--- a/R/readImgData.R
+++ b/R/readImgData.R
@@ -1,36 +1,36 @@
 #' @rdname readImgData
 #' @title Read images & scale factors for 10x Genomics Visium
-#' 
+#'
 #' @description
 #' Function to read in images and scale factors for 10x Genomics Visium data,
 #' and return as a valid \code{\link{imgData}} \code{DataFrame}.
-#' 
+#'
 #' @param path a path where to find one or more images
 #' @param sample_id the \code{sample_id} for the \code{\link{SpatialExperiment}}
 #'   object
-#' @param imageSources the images source path(s) 
+#' @param imageSources the images source path(s)
 #' @param scaleFactors the .json file where to find the scale factors
 #' @param load logical; should the image(s) be loaded into memory
 #'   as a \code{grob}? If FALSE, will store the path/URL instead.
-#' 
+#'
 #' @return a \code{\link{DataFrame}}
-#' 
+#'
 #' @author Helena L. Crowell
-#' 
-#' @examples 
+#'
+#' @examples
 #' dir <- system.file(
 #'   file.path("extdata", "10xVisium", "section1", "spatial"),
 #'   package = "SpatialExperiment")
-#'   
-#' # base directory contains 
+#'
+#' # base directory contains
 #' # - scale factors (scalefactors_json.json)
 #' # - one image (tissue_lowres_image.png)
 #' list.files(dir)
-#' 
+#'
 #' # read in images & scale factors
 #' # as valid 'imgData' 'DFrame'
 #' readImgData(dir, sample_id = "foo")
-#' 
+#'
 #' @importFrom rjson fromJSON
 #' @importFrom magick image_read image_info
 #' @export
@@ -38,8 +38,8 @@
 # TODO: change 'as' to 'load = TRUE/FALSE' &
 # support images to be supplied as path or URL
 
-readImgData <- function(path=".", sample_id=names(path), 
-    imageSources=file.path(path, "tissue_lowres_image.png"), 
+readImgData <- function(path=".", sample_id=names(path),
+    imageSources=file.path(path, "tissue_lowres_image.png"),
     scaleFactors=file.path(path, "scalefactors_json.json"),
     load=TRUE) {
 
@@ -50,15 +50,15 @@ readImgData <- function(path=".", sample_id=names(path),
         is.character(sample_id),
         length(unique(sample_id)) == length(path))
     names(path) <- names(scaleFactors) <- sample_id
-    
+
     # put images into list with one element per sample
-    images <- lapply(path, function(.) 
-        grep(., imageSources, value=TRUE))
-    
-    dfs <- lapply(sample_id, function(sid) 
+    images <- lapply(path, function(.)
+        grep(., imageSources, value=TRUE, fixed=TRUE))
+
+    dfs <- lapply(sample_id, function(sid)
     {
         sfs <- fromJSON(file=scaleFactors[sid])
-        dfs <- lapply(images[[sid]], function(img) 
+        dfs <- lapply(images[[sid]], function(img)
         {
             # get image identifier
             img_nm <- gsub("\\..*", "", basename(img))

--- a/man/readImgData.Rd
+++ b/man/readImgData.Rd
@@ -36,8 +36,8 @@ and return as a valid \code{\link{imgData}} \code{DataFrame}.
 dir <- system.file(
   file.path("extdata", "10xVisium", "section1", "spatial"),
   package = "SpatialExperiment")
-  
-# base directory contains 
+
+# base directory contains
 # - scale factors (scalefactors_json.json)
 # - one image (tissue_lowres_image.png)
 list.files(dir)


### PR DESCRIPTION
Here's the code that shows that version 1.1.701 resolves the Windows-specific issue with loading images reported at https://github.com/drighelli/SpatialExperiment/issues/64.

```R
> ## Download and save a local cache of the data provided by 10x Genomics
> bfc <- BiocFileCache::BiocFileCache()
> lymph.url <-
+     paste0(
+         "https://cf.10xgenomics.com/samples/spatial-exp/",
+         "1.1.0/V1_Human_Lymph_Node/",
+         c(
+             "V1_Human_Lymph_Node_filtered_feature_bc_matrix.tar.gz",
+             "V1_Human_Lymph_Node_spatial.tar.gz"
+         )
+     )
> lymph.data <- sapply(lymph.url, BiocFileCache::bfcrpath, x = bfc)
>
>
> ## Extract the files to a temporary location
> ## (they'll be deleted once you close your R session)
> sapply(lymph.data, utils::untar, exdir = tempdir())
https://cf.10xgenomics.com/samples/spatial-exp/1.1.0/V1_Human_Lymph_Node/V1_Human_Lymph_Node_filtered_feature_bc_matrix.tar.gz.BFC1
                                                                                                                                  0
                   https://cf.10xgenomics.com/samples/spatial-exp/1.1.0/V1_Human_Lymph_Node/V1_Human_Lymph_Node_spatial.tar.gz.BFC2
                                                                                                                                  0
>
> ## List the files we downloaded and extracted
> ## These files are typically SpaceRanger outputs
> lymph.dirs <- file.path(
+     tempdir(),
+     c("filtered_feature_bc_matrix", "spatial", "raw_feature_bc_matrix")
+ )
> list.files(lymph.dirs)
[1] "aligned_fiducials.jpg"     "barcodes.tsv.gz"           "detected_tissue_image.jpg" "features.tsv.gz"           "matrix.mtx.gz"
[6] "scalefactors_json.json"    "tissue_hires_image.png"    "tissue_lowres_image.png"   "tissue_positions_list.csv"
> spe <- read10xVisium(
+     samples = tempdir(),
+     sample_id = "lymph",
+     type = "sparse", data = "filtered",
+     images = "lowres", load = TRUE
+ )
> ## Check object
> spe
class: SpatialExperiment
dim: 36601 4035
metadata(0):
assays(1): counts
rownames(36601): ENSG00000243485 ENSG00000237613 ... ENSG00000278817 ENSG00000277196
rowData names(1): symbol
colnames(4035): AAACAAGTATCTCCCA-1 AAACAATCTACTAGCA-1 ... TTGTTTGTATTACACG-1 TTGTTTGTGTAAATTC-1
colData names(1): sample_id
reducedDimNames(0):
mainExpName: NULL
altExpNames(0):
spatialData names(3) : in_tissue array_row array_col
spatialCoords names(2) : pxl_col_in_fullres pxl_row_in_fullres
imgData names(4): sample_id image_id data scaleFactor
> imgData(spe)
DataFrame with 1 row and 4 columns
    sample_id    image_id   data scaleFactor
  <character> <character> <list>   <numeric>
1       lymph      lowres   ####   0.0510334
> options(width = 120)
> sessioninfo::session_info()
- Session info -------------------------------------------------------------------------------------------------------
 setting  value
 version  R version 4.1.0 alpha (2021-04-20 r80202)
 os       Windows 10 x64
 system   x86_64, mingw32
 ui       RStudio
 language (EN)
 collate  English_United States.1252
 ctype    English_United States.1252
 tz       America/New_York
 date     2021-05-08

- Packages -----------------------------------------------------------------------------------------------------------
 !  package              * version    date       lib source
    assertthat             0.2.1      2019-03-21 [1] CRAN (R 4.1.0)
    beachmat               2.7.7      2021-03-08 [1] Bioconductor
    Biobase              * 2.51.0     2021-03-09 [1] Bioconductor
    BiocFileCache          1.99.8     2021-05-06 [1] Bioconductor
    BiocGenerics         * 0.37.5     2021-05-04 [1] Bioconductor
    BiocParallel           1.25.5     2021-03-09 [1] Bioconductor
    bit                    4.0.4      2020-08-04 [1] CRAN (R 4.1.0)
    bit64                  4.0.5      2020-08-30 [1] CRAN (R 4.1.0)
    bitops                 1.0-7      2021-04-24 [1] CRAN (R 4.1.0)
    blob                   1.2.1      2020-01-20 [1] CRAN (R 4.1.0)
    cachem                 1.0.4      2021-02-13 [1] CRAN (R 4.1.0)
    callr                  3.7.0      2021-04-20 [1] CRAN (R 4.1.0)
    cli                    2.5.0      2021-04-26 [1] CRAN (R 4.1.0)
    crayon                 1.4.1      2021-02-08 [1] CRAN (R 4.1.0)
    curl                   4.3.1      2021-04-30 [1] CRAN (R 4.1.0)
    data.table             1.14.0     2021-02-21 [1] CRAN (R 4.1.0)
    DBI                    1.1.1      2021-01-15 [1] CRAN (R 4.1.0)
    dbplyr                 2.1.1      2021-04-06 [1] CRAN (R 4.1.0)
    DelayedArray           0.17.13    2021-05-02 [1] Bioconductor
    DelayedMatrixStats     1.13.6     2021-04-22 [1] Bioconductor
    desc                   1.3.0      2021-03-05 [1] CRAN (R 4.1.0)
    devtools             * 2.4.1      2021-05-05 [1] CRAN (R 4.1.0)
    dplyr                  1.0.6      2021-05-05 [1] CRAN (R 4.1.0)
    dqrng                  0.3.0      2021-05-01 [1] CRAN (R 4.1.0)
    DropletUtils           1.11.12    2021-03-08 [1] Bioconductor
    edgeR                  3.33.3     2021-03-09 [1] Bioconductor
    ellipsis               0.3.2      2021-04-29 [1] CRAN (R 4.1.0)
    fansi                  0.4.2      2021-01-15 [1] CRAN (R 4.1.0)
    fastmap                1.1.0      2021-01-25 [1] CRAN (R 4.1.0)
    filelock               1.0.2      2018-10-05 [1] CRAN (R 4.1.0)
    fs                     1.5.0      2020-07-31 [1] CRAN (R 4.1.0)
    generics               0.1.0      2020-10-31 [1] CRAN (R 4.1.0)
    GenomeInfoDb         * 1.27.11    2021-04-13 [1] Bioconductor
    GenomeInfoDbData       1.2.5      2021-05-08 [1] Bioconductor
    GenomicRanges        * 1.43.4     2021-04-04 [1] Bioconductor
    glue                   1.4.2      2020-08-27 [1] CRAN (R 4.1.0)
    HDF5Array              1.19.16    2021-05-02 [1] Bioconductor
    hms                    1.0.0      2021-01-13 [1] CRAN (R 4.1.0)
    httr                   1.4.2      2020-07-20 [1] CRAN (R 4.1.0)
    IRanges              * 2.25.11    2021-05-05 [1] Bioconductor
    lattice                0.20-44    2021-05-02 [1] CRAN (R 4.1.0)
    lifecycle              1.0.0      2021-02-15 [1] CRAN (R 4.1.0)
    limma                  3.47.13    2021-05-02 [1] Bioconductor
    locfit                 1.5-9.4    2020-03-25 [1] CRAN (R 4.1.0)
    lubridate              1.7.10     2021-02-26 [1] CRAN (R 4.1.0)
    magick                 2.7.2      2021-05-02 [1] CRAN (R 4.1.0)
    magrittr               2.0.1      2020-11-17 [1] CRAN (R 4.1.0)
    Matrix                 1.3-3      2021-05-04 [1] CRAN (R 4.1.0)
    MatrixGenerics       * 1.3.1      2021-03-08 [1] Bioconductor
    matrixStats          * 0.58.0     2021-01-29 [1] CRAN (R 4.1.0)
    memoise                2.0.0      2021-01-26 [1] CRAN (R 4.1.0)
    pillar                 1.6.0      2021-04-13 [1] CRAN (R 4.1.0)
    pkgbuild               1.2.0      2020-12-15 [1] CRAN (R 4.1.0)
    pkgconfig              2.0.3      2019-09-22 [1] CRAN (R 4.1.0)
    pkgload                1.2.1      2021-04-06 [1] CRAN (R 4.1.0)
    prettyunits            1.1.1      2020-01-24 [1] CRAN (R 4.1.0)
    processx               3.5.2      2021-04-30 [1] CRAN (R 4.1.0)
    ps                     1.6.0      2021-02-28 [1] CRAN (R 4.1.0)
    purrr                  0.3.4      2020-04-17 [1] CRAN (R 4.1.0)
    R.methodsS3            1.8.1      2020-08-26 [1] CRAN (R 4.1.0)
    R.oo                   1.24.0     2020-08-26 [1] CRAN (R 4.1.0)
    R.utils                2.10.1     2020-08-26 [1] CRAN (R 4.1.0)
    R6                     2.5.0      2020-10-28 [1] CRAN (R 4.1.0)
    rappdirs               0.3.3      2021-01-31 [1] CRAN (R 4.1.0)
    Rcpp                   1.0.6      2021-01-15 [1] CRAN (R 4.1.0)
    RCurl                  1.98-1.3   2021-03-16 [1] CRAN (R 4.1.0)
    remotes                2.3.0      2021-04-01 [1] CRAN (R 4.1.0)
    rhdf5                  2.35.2     2021-03-08 [1] Bioconductor
 D  rhdf5filters           1.3.5      2021-04-30 [1] Bioconductor
    Rhdf5lib               1.13.6     2021-05-04 [1] Bioconductor
    rjson                  0.2.20     2018-06-08 [1] CRAN (R 4.1.0)
    rlang                  0.4.11     2021-04-30 [1] CRAN (R 4.1.0)
    rprojroot              2.0.2      2020-11-15 [1] CRAN (R 4.1.0)
    RSQLite                2.2.7      2021-04-22 [1] CRAN (R 4.1.0)
    rsthemes               0.2.1.9000 2021-04-22 [1] Github (gadenbuie/rsthemes@19299e5)
    rstudioapi             0.13       2020-11-12 [1] CRAN (R 4.1.0)
    S4Vectors            * 0.29.19    2021-05-06 [1] Bioconductor
    scuttle                1.1.18     2021-03-08 [1] Bioconductor
    sessioninfo            1.1.1      2018-11-05 [1] CRAN (R 4.1.0)
    SingleCellExperiment * 1.13.14    2021-04-13 [1] Bioconductor
    sparseMatrixStats      1.3.8      2021-04-28 [1] Bioconductor
 VP SpatialExperiment    * 1.1.701    2021-05-05 [?] Bioconductor
    SummarizedExperiment * 1.21.3     2021-04-13 [1] Bioconductor
    suncalc                0.5.0      2019-04-03 [1] CRAN (R 4.1.0)
    testthat             * 3.0.2      2021-02-14 [1] CRAN (R 4.1.0)
    tibble                 3.1.1      2021-04-18 [1] CRAN (R 4.1.0)
    tidyselect             1.1.1      2021-04-30 [1] CRAN (R 4.1.0)
    tinytex                0.31       2021-03-30 [1] CRAN (R 4.1.0)
    usethis              * 2.0.1      2021-02-10 [1] CRAN (R 4.1.0)
    utf8                   1.2.1      2021-03-12 [1] CRAN (R 4.1.0)
    vctrs                  0.3.8      2021-04-29 [1] CRAN (R 4.1.0)
    withr                  2.4.2      2021-04-18 [1] CRAN (R 4.1.0)
    xfun                   0.22       2021-03-11 [1] CRAN (R 4.1.0)
    XVector                0.31.1     2021-03-08 [1] Bioconductor
    zlibbioc               1.37.0     2021-03-09 [1] Bioconductor

[1] C:/R/R-4.1.0alpha/library

 V -- Loaded and on-disk version mismatch.
 P -- Loaded and on-disk path mismatch.
 D -- DLL MD5 mismatch, broken installation.
```