### PR TITLE
Update readme on GitHub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SpatialExperiment
 Type: Package
 Title: S4 Class for Spatial Experiments handling 
-Version: 1.3.2
+Version: 1.3.3
 Date: 2021-05-07
 Authors@R: c(
     person("Dario", "Righelli", role=c("aut", "cre"), 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: SpatialExperiment
 Type: Package
 Title: S4 Class for Spatial Experiments handling 
 Version: 1.3.3
-Date: 2021-07-27
+Date: 2021-07-29
 Authors@R: c(
     person("Dario", "Righelli", role=c("aut", "cre"), 
         email="dario.righelli@gmail.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: SpatialExperiment
 Type: Package
 Title: S4 Class for Spatial Experiments handling 
 Version: 1.3.3
-Date: 2021-05-07
+Date: 2021-07-27
 Authors@R: c(
     person("Dario", "Righelli", role=c("aut", "cre"), 
         email="dario.righelli@gmail.com"),

--- a/README.md
+++ b/README.md
@@ -1,66 +1,25 @@
 # SpatialExperiment
 
-SpatialExperiment package provides an S4 class for Spatial Omics data handling.
+`SpatialExperiment` is a Bioconductor class designed to represent spatially resolved transcriptomics data.
 
-Since version 1.1.42 SpatialExperiment package has changed in several ways.
+The `SpatialExperiment` package is available from [Bioconductor](https://bioconductor.org/packages/SpatialExperiment).
 
-+ VisiumExperiment and SpatialExperiment classes are merged into the
-SpatialExperiment class.
-+ Newer version of SpatialExperiment has image loading handling with `imgData` 
-structure
-+ Molecular-based data can be handled with `molecular` [BumpyMatrix](http://bioconductor.org/packages/BumpyMatrix/) assay.
-+ 10x Visium standard data import support with `read10xVisium` function.
-+ Check vignettes and documentation for further details.
+A vignette containing examples and documentation is available from the Bioconductor page.
 
 
-# Installation
+## Installation
 
-SpatialExperiment is available on the [Bioductor official repository](https://bioconductor.org/packages/SpatialExperiment/).
-Today (January 2021) version 1.1.42 is available on Bioconductor devel (v3.13).
-
-To install it use:
+The `SpatialExperiment` package can be installed using standard Bioconductor installation procedures. For more details, see the Bioconductor website.
 
 ```
-if (!requireNamespace("BiocManager", quietly = TRUE))
-    install.packages("BiocManager")
-
-# The following initializes usage of Bioc devel
-BiocManager::install(version='devel')
-
+install.packages("BiocManager")
 BiocManager::install("SpatialExperiment")
 ```
 
-or, alternatively, use the following for the latest github-devel version:
 
-```
-if (!requireNamespace("BiocManager", quietly = TRUE))
-    install.packages("BiocManager")
-BiocManager::install("drighelli/SpatialExperiment")
-```
+## Paper and citation
 
-# Add-ons
+Additional details are provided in our paper:
 
-## Spatial Experiment and multimodal data 
-
-SpatialExperiment class can be included into a MultiAssayExperiment object as 
-a dedicated assay.
-Check how it handles seqFISH data into the `SingleCellMultiModal::seqFISH()`
-package function.
-
-SingleCellMultiModal is available in Bioconductor and can be installed via:
-
-```
-if (!requireNamespace("BiocManager", quietly = TRUE))
-    install.packages("BiocManager")
-
-BiocManager::install("SingleCellMultiModal")
-```
-
-
-## Spatial Analysis
-
-To provide additional examples for spatial transcriptomics analysis we're constantly populating the https://github.com/drighelli/SpatialAnalysisWorkflows repository.
-
-These will hopefully find a place into a dedicated package for Spatial Transcriptomics data analysis examples.
-
+[Righell D.\*, Weber L.M.\*, Crowell H.L.\*, Pardo B., Collado-Torres L., Ghazanfar S., Lun A.T.L., Hicks S.C.<sup>+</sup>, and Risso D.<sup>+</sup> (2021), *SpatialExperiment: infrastructure for spatially resolved transcriptomics data in R using Bioconductor*, bioRxiv, 2021.01.27.428431v1](https://www.biorxiv.org/content/10.1101/2021.01.27.428431v1)
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,7 @@
+changes in version 1.3.2 (2021-07-27)
++ spatialData moved from colData to int_colData
++ restructuring of vignette and added imgData section
+
 changes in version 1.1.700 (2021-05-05)
 + updating roles in DESCRIPTION file
 + adding GeneExpression biocVie


### PR DESCRIPTION
Updated the readme page on GitHub - simplified / reduced the information provided, and referring readers to the Bioconductor page and vignette for further details.

This is forked from the `spatialData` branch so best to merge after that one (alternatively we can change the version numbers to fix merge conflicts if merging directly into `master`).