### PR TITLE
Fix version number for Bioc-devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SpatialExperiment
 Type: Package
 Title: S4 Class for Spatially Resolved Transcriptomics Data
-Version: 1.3.7
+Version: 1.5.1
 Date: 2021-12-15
 Authors@R: c(
     person("Dario", "Righelli", role=c("aut", "cre"), 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,4 +1,4 @@
-changes in version 1.3.7 (2021-12-15)
+changes in version 1.5.1 (2021-12-15)
 + improved coercion methods from SingleCellExperiment to SpatialExperiment
 + add new methods for image rotation/mirroring
 + add path argument to imgSource()


### PR DESCRIPTION
This is to fix the version numbers to merge our last set of updates into Bioc-devel.

I previously put 1.3.7 but this gave a merge conflict when pushing to upstream since the version number in Bioc-devel is already at 1.5.0. So it needs to be 1.5.1 instead.