### PR TITLE
Additional installation instructions on GitHub readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ remotes::install_github("drighelli/SpatialExperiment")
 
 In version 1.5.2 (2022-01-09) the `spatialData` slot was deprecated, with columns previously stored in `spatialData` now recommended to be stored in `colData`. The `spatialCoords` slot (`x` and `y` coordinates) is unchanged. Existing objects are backward-compatible (and a console message is returned if `spatialData` is still used), however we recommend re-building existing objects to move the contents of `spatialData` to `colData` to ensure longer-term compatibility with any future updates.
 
-**To use version 1.5.2 or later (as of January 2022), please follow the installation instructions for the development version above.** (These updates will be available in the release version from mid-April 2022 onwards, following the Bioconductor release schedule.)
+**To use version 1.5.2 or later (as of January 2022), please follow the installation instructions for the development version above.**
+
+(These updates will also be available in the release version from mid-April 2022 onwards, following the Bioconductor release schedule.)
 
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -1,25 +1,52 @@
 # SpatialExperiment
 
-`SpatialExperiment` is a Bioconductor class designed to represent spatially resolved transcriptomics data.
+`SpatialExperiment` is an R/Bioconductor S4 class for storing data from spatially resolved transcriptomics (ST) experiments. The class extends the `SingleCellExperiment` class for single-cell data to support storage and retrieval of additional information from spot-based and molecule-based ST platforms, including spatial coordinates, images, and image metadata. A specialized constructor function is included for data from the 10x Genomics Visium platform.
 
 The `SpatialExperiment` package is available from [Bioconductor](https://bioconductor.org/packages/SpatialExperiment).
 
-A vignette containing examples and documentation is available from the Bioconductor page.
+A vignette containing examples and documentation is available from [Bioconductor](https://bioconductor.org/packages/SpatialExperiment), and additional details are provided in our [preprint](https://www.biorxiv.org/content/10.1101/2021.01.27.428431v2).
 
 
 ## Installation
 
-The `SpatialExperiment` package can be installed using standard Bioconductor installation procedures. For more details, see the Bioconductor website.
+The `SpatialExperiment` package can be installed from Bioconductor. Note that Bioconductor follows a "release" and "development" schedule, where the release version is considered to be stable and updated every 6 months, and the development version contains latest updates (and then becomes the next release version every 6 months).
+
+
+### Release version
+
+To install the stable release version, install the latest release version of R from [CRAN](https://cran.r-project.org/), then install the Bioconductor package installer and the `SpatialExperiment` package as follows.
 
 ```
 install.packages("BiocManager")
 BiocManager::install("SpatialExperiment")
 ```
 
+### Development version
 
-## Paper and citation
+To install the development version, there are two options.
 
-Additional details are provided in our paper:
+(i) Install the [appropriate version of R (R-release between April and October, or R-devel between October and April)](http://bioconductor.org/developers/how-to/useDevel/), then install the Bioconductor package installer and the development version of the `SpatialExperiment` package as follows.
 
-[Righell D.\*, Weber L.M.\*, Crowell H.L.\*, Pardo B., Collado-Torres L., Ghazanfar S., Lun A.T.L., Hicks S.C.<sup>+</sup>, and Risso D.<sup>+</sup> (2021), *SpatialExperiment: infrastructure for spatially resolved transcriptomics data in R using Bioconductor*, bioRxiv, 2021.01.27.428431v1](https://www.biorxiv.org/content/10.1101/2021.01.27.428431v1)
+```
+install.packages("BiocManager")
+BiocManager::install("SpatialExperiment", version = "devel")
+```
+
+(ii) Alternatively, if you do not want to install R-devel (since this may cause issues with other packages), you can use the latest release version of R from [CRAN](https://cran.r-project.org/) and install the development version of the `SpatialExperiment` package from GitHub as follows.
+
+```
+install.packages("remotes")
+remotes::install_github("drighelli/SpatialExperiment")
+```
+
+### Updates in version 1.5.2 (2022-01-09)
+
+In version 1.5.2 (2022-01-09) the `spatialData` slot was deprecated, with columns previously stored in `spatialData` now recommended to be stored in `colData`. The `spatialCoords` slot (`x` and `y` coordinates) is unchanged. Existing objects are backward-compatible (and a console message is returned if `spatialData` is still used), however we recommend re-building existing objects to move the contents of `spatialData` to `colData` to ensure longer-term compatibility with any future updates.
+
+**To use version 1.5.2 or later (as of January 2022), please follow the installation instructions for the development version above.** (These updates will be available in the release version from mid-April 2022 onwards, following the Bioconductor release schedule.)
+
+
+## Citation
+
+Righell D.\*, Weber L.M.\*, Crowell H.L.\*, Pardo B., Collado-Torres L., Ghazanfar S., Lun A.T.L., Hicks S.C.<sup>+</sup>, and Risso D.<sup>+</sup> (2021), *SpatialExperiment: infrastructure for spatially resolved transcriptomics data in R using Bioconductor*, [bioRxiv](https://www.biorxiv.org/content/10.1101/2021.01.27.428431v2).
 


### PR DESCRIPTION
Adding additional installation instructions for `release` and `devel` versions on GitHub readme page.

This is to address one of the reviewer comments, i.e. explaining more clearly how to install the `release` and `devel` versions for users who may not be completely familiar with Bioconductor.

I have also included a section on version 1.5.2 (`spatialData` / `colData` updates) to make it clear that this version needs to be used for the updates described in our revised paper. We can remove this paragraph again later (after Bioc release date in April), but I think we should include this for now for the reviewer and any other users who are upgrading to the new version.