### PR TITLE
Additional backward compatibility for spatialData accessor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SpatialExperiment
 Type: Package
 Title: S4 Class for Spatially Resolved Transcriptomics Data
-Version: 1.5.2
-Date: 2022-01-09
+Version: 1.5.3
+Date: 2022-02-02
 Authors@R: c(
     person("Dario", "Righelli", role=c("aut", "cre"), 
         email="dario.righelli@gmail.com"),

--- a/R/SpatialExperiment-methods.R
+++ b/R/SpatialExperiment-methods.R
@@ -270,6 +270,6 @@ setMethod("scaleFactors",
 .msg_spatialData <- function() {
     message(paste0(
         "Note: the use of spatialData/spatialDataNames has been deprecated in ", 
-        "SPE version 1.5.2 onwards. All columns should now be stored in ", 
-        "colData and spatialCoords instead."))
+        "SpatialExperiment version 1.5.2 onwards. All columns should now be ", 
+        "stored in colData and spatialCoords instead."))
 }

--- a/R/SpatialExperiment-methods.R
+++ b/R/SpatialExperiment-methods.R
@@ -107,11 +107,16 @@ NULL
 
 #' @rdname SpatialExperiment-methods
 #' @importFrom SummarizedExperiment colData
+#' @importFrom SingleCellExperiment int_colData
 #' @export
-setMethod("spatialData", 
+setMethod("spatialData",
     "SpatialExperiment",
     function(x) {
-      colData(x)[spatialDataNames(x)]
+        spd <- colData(x)[spatialDataNames(x)]
+        if (ncol(spd) == 0 & !is.null(int_colData(x)$spatialData)) {
+            spd <- int_colData(x)$spatialData
+        }
+        spd
     }
 )
 

--- a/R/SpatialExperiment-methods.R
+++ b/R/SpatialExperiment-methods.R
@@ -269,6 +269,7 @@ setMethod("scaleFactors",
 # message for deprecation of spatialData/Names
 .msg_spatialData <- function() {
     message(paste0(
-        "Note: spatialData and spatialDataNames have been deprecated; all ", 
-        "columns should be stored in colData and spatialCoords"))
+        "Note: the use of spatialData/spatialDataNames has been deprecated in ", 
+        "SPE version 1.5.2 onwards. All columns should now be stored in ", 
+        "colData and spatialCoords instead."))
 }

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,6 @@
+changes in version 1.5.3 (2022-02-02)
++ additional backward compatibility in spatialData accessor
+
 changes in version 1.5.2 (2022-01-09)
 + relocate and deprecate spatialData/Names
 

--- a/tests/testthat/test_SpatialExperiment-methods.R
+++ b/tests/testthat/test_SpatialExperiment-methods.R
@@ -45,6 +45,13 @@ test_that("spatialDataNames()<-,NULL", {
     expect_identical(new, character(0))
 })
 
+test_that("spatialData accessor backward compatibility SPE version < 1.5.2", {
+    int_colData(spe)$spatialData <- colData(spe)[, "in_tissue", drop = FALSE]
+    spd <- spatialData(spe)
+    expect_equal(ncol(spd), 1)
+    expect_equal(colnames(spd), "in_tissue")
+})
+
 test_that("spatialCoordsNames()", {
     expect_identical(
         spatialCoordsNames(spe), 


### PR DESCRIPTION
This is a minor update to the `spatialData()` accessor so that users can still easily access columns stored in `spatialData` for objects built with the earlier versions of `SpatialExperiment` < 1.5.2.

Over the longer term I think the plan will still be to deprecate `spatialData` entirely, but I think this update is helpful since it means people's existing analysis code won't immediately break if they update to SPE version 1.5.2 in the next few weeks and are still using their old SPE objects.

Some more details are in issue #96 

Let me know what you think. I tried this just now on some of my old objects and I think it is working correctly, i.e. the `spatialData()` accessor returns the columns and a warning message.

I also included a unit test and NEWS, and slightly changed the warning message to make it more descriptive.