### PR TITLE
Version bump for Bioc builders

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: SpatialExperiment
-Version: 1.9.1
+Version: 1.9.2
 Title: S4 Class for Spatially Resolved Transcriptomics Data
 Description: Defines an S4 class for storing data from spatially resolved 
     transcriptomics (ST) experiments. The class extends SingleCellExperiment to 


### PR DESCRIPTION
There was a glitch with the Bioc builders yesterday (see discussion in Bioc Slack in channel `#developers-forum`), so yesterday's merge didn't work.

This has now been resolved (see comments from Lori Shepherd in the channel) but we need to add a new version bump for yesterday's merge and then push to upstream again. Thank you!