### PR TITLE
Bugfix for tissue positions read in incorrect order (release version)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: SpatialExperiment
-Version: 1.8.0
+Version: 1.8.1
 Title: S4 Class for Spatially Resolved Transcriptomics Data
 Description: Defines an S4 class for storing data from spatially resolved 
     transcriptomics (ST) experiments. The class extends SingleCellExperiment to 

--- a/R/read10xVisium.R
+++ b/R/read10xVisium.R
@@ -124,11 +124,12 @@ read10xVisium <- function(samples="",
     # otherwise things will fail & give unhelpful error messages
     
     dir <- file.path(samples, "spatial")
+    suffix <- c("", "_list")
     xyz <- file.path(
-        rep(dir, each = 2), 
+        rep(dir, each = length(suffix)), 
         sprintf(
             "tissue_positions%s.csv", 
-            rep(c("", "_list"), length(sids))))
+            rep(suffix, length(sids))))
     xyz <- xyz[file.exists(xyz)]
     sfs <- file.path(dir, "scalefactors_json.json")
     names(xyz) <- names(sfs) <- sids

--- a/R/read10xVisium.R
+++ b/R/read10xVisium.R
@@ -125,7 +125,7 @@ read10xVisium <- function(samples="",
     
     dir <- file.path(samples, "spatial")
     xyz <- file.path(
-        rep(dir, each = length(sids)), 
+        rep(dir, each = 2), 
         sprintf(
             "tissue_positions%s.csv", 
             rep(c("", "_list"), length(sids))))

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,7 @@
+changes in version 1.8.1 (2023-03-02)
++ bugfix for tissue positions read in incorrect order with read10xVisium() in 
+  datasets with multiple samples (bug introduced in version 1.7.1)
+
 changes in version 1.7.2 (2022-10-07)
 + support for seeing colData names with $ in RStudio
 

--- a/tests/testthat/test_read10xVisium.R
+++ b/tests/testthat/test_read10xVisium.R
@@ -72,3 +72,33 @@ test_that("adding 'outs/' directory works correctly for one or more samples", {
     expect_identical(x1, x2)
     expect_identical(x1, x3)
 })
+
+test_that(paste0("tissue positions files are read in correct sample order and ", 
+                 "spatial coordinates are in correct order in SPE object", 
+                 "in datasets with multiple samples"), {
+    # read in 4 samples and check spatial coordinates are in correct order
+    # correct sample order is: section1, section2, section1, section2
+    samples <- c(samples, samples)
+    sample_ids <- c(sample_ids, paste0(sample_ids, "rep"))
+    
+    spatial_coords_1 <- spatialCoords(
+      read10xVisium(samples[1], sample_ids[1], type = "sparse", 
+                    data = "raw", images = "lowres", load = FALSE))
+    spatial_coords_2 <- spatialCoords(
+      read10xVisium(samples[2], sample_ids[2], type = "sparse", 
+                    data = "raw", images = "lowres", load = FALSE))
+    
+    spatial_coords_multi <- spatialCoords(
+      read10xVisium(samples, sample_ids, type = "sparse", 
+                    data = "raw", images = "lowres", load = FALSE))
+    
+    # correct number of spatial locations
+    expect_equal(
+        nrow(spatial_coords_multi), 
+        2 * nrow(spatial_coords_1) + 2 * nrow(spatial_coords_2))
+    
+    # spatial coordinates are in correct order
+    expect_identical(
+        spatial_coords_multi, 
+        rbind(spatial_coords_1, spatial_coords_2, spatial_coords_1, spatial_coords_2))
+})

--- a/tests/testthat/test_read10xVisium.R
+++ b/tests/testthat/test_read10xVisium.R
@@ -100,5 +100,6 @@ test_that(paste0("tissue positions files are read in correct sample order and ",
     # spatial coordinates are in correct order
     expect_identical(
         spatial_coords_multi, 
-        rbind(spatial_coords_1, spatial_coords_2, spatial_coords_1, spatial_coords_2))
+        rbind(spatial_coords_1, spatial_coords_2, 
+              spatial_coords_1, spatial_coords_2))
 })


### PR DESCRIPTION
This is the same bugfix for tissue positions currently being read in incorrect order by `read10xVisium()` from issue #135 and PR #136 .

This PR git cherry-picks the fix from @lcolladotor and the unit test from me so we can patch the bugfix into the release version too.

If we need to make any further edits in the devel branch in the main PR then I will cherry-pick them over here too. Otherwise @HelenaLC @drighelli could you please check and approve here too. Thank you!