### PR TITLE
Deprecate read10xVisium()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: SpatialExperiment
-Version: 1.15.1
+Version: 1.15.2
 Title: S4 Class for Spatially Resolved -omics Data
 Description: Defines an S4 class for storing data from spatial -omics experiments. 
     The class extends SingleCellExperiment to 
@@ -9,13 +9,17 @@ Description: Defines an S4 class for storing data from spatial -omics experiment
     from the 10x Genomics Visium platform.
 Authors@R: c(
     person("Dario", "Righelli", role=c("aut", "cre"), 
-        email="dario.righelli@gmail.com"), 
+        email="dario.righelli@gmail.com",
+        comment=c(ORCID="0000-0003-1504-3583")),
     person("Davide", "Risso", role=c("aut"), 
-        email="risso.davide@gmail.com"), 
+        email="risso.davide@gmail.com",
+        comment=c(ORCID="0000-0001-8508-5012")),
     person("Helena L.", "Crowell", role=c("aut"), 
-        email="helena.crowell@uzh.ch"), 
+        email="helena.crowell@cnag.eu",
+        comment=c(ORCID="0000-0002-4801-1767")), 
     person("Lukas M.", "Weber", role=c("aut"), 
-        email="lukas.weber.edu@gmail.com"),
+        email="lukas.weber.edu@gmail.com",
+        comment=c(ORCID="0000-0002-3282-1730")), 
     person("Nicholas J.", "Eagles", role=c("ctb"),
         email="nickeagles77@gmail.com"))
 URL: https://github.com/drighelli/SpatialExperiment
@@ -49,6 +53,7 @@ Suggests:
     testthat, 
     BiocStyle, 
     BumpyMatrix, 
-    DropletUtils
+    DropletUtils,
+    VisiumIO
 VignetteBuilder: knitr
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Authors@R: c(
         email="helena.crowell@cnag.eu",
         comment=c(ORCID="0000-0002-4801-1767")), 
     person("Lukas M.", "Weber", role=c("aut"), 
-        email="lukas.weber.edu@gmail.com",
+        email="lmweberedu@gmail.com",
         comment=c(ORCID="0000-0002-3282-1730")), 
     person("Nicholas J.", "Eagles", role=c("ctb"),
         email="nickeagles77@gmail.com"))

--- a/R/SpatialExperiment-colData.R
+++ b/R/SpatialExperiment-colData.R
@@ -24,7 +24,7 @@
 #' @return a \code{\link{SpatialExperiment}} object with updated \code{colData}
 #' 
 #' @examples
-#' example(read10xVisium)
+#' example("SpatialExperiment-methods")
 #' 
 #' # empty replacement retains sample identifiers
 #' colData(spe) <- NULL

--- a/R/SpatialExperiment-colData.R
+++ b/R/SpatialExperiment-colData.R
@@ -24,7 +24,7 @@
 #' @return a \code{\link{SpatialExperiment}} object with updated \code{colData}
 #' 
 #' @examples
-#' example("SpatialExperiment-methods")
+#' example(SpatialExperiment)
 #' 
 #' # empty replacement retains sample identifiers
 #' colData(spe) <- NULL

--- a/R/SpatialExperiment-combine.R
+++ b/R/SpatialExperiment-combine.R
@@ -45,7 +45,7 @@
 #' Dario Righelli
 #' 
 #' @examples
-#' example(read10xVisium, echo = FALSE)
+#' example(SpatialExperiment)
 #'
 #' # merging with duplicated 'sample_id's
 #' # will automatically assign unique identifiers

--- a/R/SpatialExperiment-methods.R
+++ b/R/SpatialExperiment-methods.R
@@ -89,7 +89,7 @@
 #' @return Return value varies depending on method, as described below.
 #' 
 #' @examples
-#' example(read10xVisium)
+#' example(SpatialExperiment)
 #' 
 #' # spatialCoords returns a numeric matrix
 #' head(spatialCoords(spe))

--- a/R/SpatialExperiment-rotate-mirror.R
+++ b/R/SpatialExperiment-rotate-mirror.R
@@ -65,7 +65,7 @@
 #' @author Nicholas J. Eagles
 #' 
 #' @examples
-#' example(read10xVisium)
+#' example(SpatialExperiment)
 #' 
 #' # rotateCoords(), mirrorCoords(), rotateObject(), and mirrorObject() return a
 #' # SpatialExperiment, potentially subsetted by sample.

--- a/R/SpatialExperiment.R
+++ b/R/SpatialExperiment.R
@@ -85,9 +85,9 @@
 #' To combine multiple samples within a single object, see
 #' \code{\link{combine}}.
 #' 
-#' For 10x Genomics Visium datasets, the \code{\link[VisiumIO]{TENxVisiumList}} 
-#' and \code{\link[VisiumIO]{import}} functions can be used to load data into 
-#' a \code{SpatialExperiment} object directly from Space Ranger output files.
+#' For 10x Genomics Visium datasets, the \code{TENxVisiumList} and \code{import}
+#' functions from the \code{VisiumIO} package can be used to load data into a 
+#' \code{SpatialExperiment} object directly from Space Ranger output files.
 #' 
 #' @seealso
 #' \code{?"\link{SpatialExperiment-methods}"}, which includes:

--- a/R/SpatialExperiment.R
+++ b/R/SpatialExperiment.R
@@ -85,9 +85,9 @@
 #' To combine multiple samples within a single object, see
 #' \code{\link{combine}}.
 #' 
-#' For 10x Genomics Visium datasets, the function \code{\link{read10xVisium}}
-#' can be used to load data and create a \code{SpatialExperiment} object
-#' directly from Space Ranger output files.
+#' For 10x Genomics Visium datasets, the \code{\link[VisiumIO]{TENxVisiumList}} 
+#' and \code{\link[VisiumIO]{import}} functions can be used to load data into 
+#' a \code{SpatialExperiment} object directly from Space Ranger output files.
 #' 
 #' @seealso
 #' \code{?"\link{SpatialExperiment-methods}"}, which includes:
@@ -110,8 +110,6 @@
 #' \code{?"\link{imgData-methods}"}
 #' 
 #' \code{\link{SpatialImage}}
-#' 
-#' \code{\link{read10xVisium}}
 #' 
 #' @author Dario Righelli and Helena L. Crowell
 #' 
@@ -156,11 +154,19 @@
 #'     sample_id = "foo"))
 #'     
 #' #############################################################
-#' # Example 2: Spot-based ST (10x Visium) using 'read10xVisium'
+#' # Example 2: Spot-based ST (10x Visium) using 'VisiumIO'
 #' #############################################################
 #' 
-#' # see ?read10xVisium for details
-#' example(read10xVisium)
+#' library(VisiumIO)
+#' dir <- list.dirs(system.file(
+#'   file.path("extdata", "10xVisium"),
+#'   package = "SpatialExperiment"), 
+#'   recursive = FALSE, full.names = TRUE)
+#' (spe <- import(TENxVisiumList(
+#'   sampleFolders = dir, 
+#'   sample_ids = basename(dir), 
+#'   processing = "raw", 
+#'   images = "lowres")))
 #' 
 #' ##############################
 #' # Example 3: Molecule-based ST

--- a/R/imgData-methods.R
+++ b/R/imgData-methods.R
@@ -66,7 +66,7 @@
 #' with modified a \code{raster} matrix.
 #'   
 #' @examples
-#' example(read10xVisium)
+#' example(SpatialExperiment)
 #' 
 #' # 'SpatialImage' accession
 #' (spi <- getImg(spe))

--- a/R/read10xVisium.R
+++ b/R/read10xVisium.R
@@ -92,6 +92,8 @@ read10xVisium <- function(samples="",
     images="lowres",
     load=TRUE) {
     
+    .Deprecated("VisiumIO::TENxVisium(List)")
+    
     # check if DropletUtils is installed
     if (!requireNamespace("DropletUtils", quietly = TRUE)) {
         warning("DropletUtils package must be installed to use read10xVisium()")

--- a/R/show.R
+++ b/R/show.R
@@ -14,7 +14,7 @@
 #' @author Dario Righelli and Helena L. Crowell
 #' 
 #' @examples
-#' example(read10xVisium)
+#' example(SpatialExperiment)
 #' spe
 NULL
 

--- a/R/subset.R
+++ b/R/subset.R
@@ -22,7 +22,7 @@
 #' @return a \code{\link{SpatialExperiment}} object
 #' 
 #' @examples
-#' example(read10xVisium)
+#' example(SpatialExperiment)
 #' 
 #' dim(spe)
 #' 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,12 @@
+changes in version 1.15.2 (2024-06-21)
++ deprecation of read10xVisium() in favor of VisiumIO's TENxVisiumList()
+
+changes in version 1.15.1 (2024-06-20)
++ bug fix (#151): getImg now handles non-character sample and image IDs
+
+changes in version 1.15.0 (2024-05-01)
++ Bioconductor 3.19 release
+
 changes in version 1.11.2 (2023-09-01)
 + move DropletUtils package to Suggests
 

--- a/man/SpatialExperiment-colData.Rd
+++ b/man/SpatialExperiment-colData.Rd
@@ -10,7 +10,7 @@
 \usage{
 \S4method{colData}{SpatialExperiment,DataFrame}(x) <- value
 
-\S4method{colData}{SpatialExperiment,`NULL`}(x) <- value
+\S4method{colData}{SpatialExperiment,NULL}(x) <- value
 }
 \arguments{
 \item{x}{a \code{\link{SpatialExperiment}}}
@@ -35,7 +35,7 @@ retained. In addition, checks are performed against the \code{sample_id}s in
 \code{\link{imgData}}.
 }
 \examples{
-example(read10xVisium)
+example("SpatialExperiment-methods")
 
 # empty replacement retains sample identifiers
 colData(spe) <- NULL

--- a/man/SpatialExperiment-colData.Rd
+++ b/man/SpatialExperiment-colData.Rd
@@ -35,7 +35,7 @@ retained. In addition, checks are performed against the \code{sample_id}s in
 \code{\link{imgData}}.
 }
 \examples{
-example("SpatialExperiment-methods")
+example(SpatialExperiment)
 
 # empty replacement retains sample identifiers
 colData(spe) <- NULL

--- a/man/SpatialExperiment-combine.Rd
+++ b/man/SpatialExperiment-combine.Rd
@@ -51,7 +51,7 @@ Refer to \code{?\link[base]{cbind}} for the interpretation of
 }
 
 \examples{
-example(read10xVisium, echo = FALSE)
+example(SpatialExperiment)
 
 # merging with duplicated 'sample_id's
 # will automatically assign unique identifiers

--- a/man/SpatialExperiment-methods.Rd
+++ b/man/SpatialExperiment-methods.Rd
@@ -36,25 +36,25 @@
 
 \S4method{spatialData}{SpatialExperiment,DFrame}(x) <- value
 
-\S4method{spatialData}{SpatialExperiment,`NULL`}(x) <- value
+\S4method{spatialData}{SpatialExperiment,NULL}(x) <- value
 
 \S4method{spatialDataNames}{SpatialExperiment}(x)
 
 \S4method{spatialDataNames}{SpatialExperiment,character}(x) <- value
 
-\S4method{spatialDataNames}{SpatialExperiment,`NULL`}(x) <- value
+\S4method{spatialDataNames}{SpatialExperiment,NULL}(x) <- value
 
 \S4method{spatialCoords}{SpatialExperiment}(x)
 
 \S4method{spatialCoords}{SpatialExperiment,matrix}(x) <- value
 
-\S4method{spatialCoords}{SpatialExperiment,`NULL`}(x) <- value
+\S4method{spatialCoords}{SpatialExperiment,NULL}(x) <- value
 
 \S4method{spatialCoordsNames}{SpatialExperiment}(x)
 
 \S4method{spatialCoordsNames}{SpatialExperiment,character}(x) <- value
 
-\S4method{spatialCoordsNames}{SpatialExperiment,`NULL`}(x) <- value
+\S4method{spatialCoordsNames}{SpatialExperiment,NULL}(x) <- value
 
 \S4method{scaleFactors}{SpatialExperiment}(x, sample_id = TRUE, image_id = TRUE)
 
@@ -64,7 +64,7 @@
 
 \S4method{imgData}{SpatialExperiment,DataFrame}(x) <- value
 
-\S4method{imgData}{SpatialExperiment,`NULL`}(x) <- value
+\S4method{imgData}{SpatialExperiment,NULL}(x) <- value
 }
 \arguments{
 \item{x}{A \code{\link{SpatialExperiment}} object.}
@@ -159,7 +159,7 @@ methods to rotate and mirror SpatialExperiment objects and their
 }
 
 \examples{
-example(read10xVisium)
+example(SpatialExperiment)
 
 # spatialCoords returns a numeric matrix
 head(spatialCoords(spe))

--- a/man/SpatialExperiment-misc.Rd
+++ b/man/SpatialExperiment-misc.Rd
@@ -19,7 +19,7 @@ descendants that do not fit into any other documentation category such as,
 for example, show methods.
 }
 \examples{
-example(read10xVisium)
+example(SpatialExperiment)
 spe
 }
 \author{

--- a/man/SpatialExperiment-rotate-mirror.Rd
+++ b/man/SpatialExperiment-rotate-mirror.Rd
@@ -90,7 +90,7 @@ Additional details for each type of data attribute are provided below.
 }
 
 \examples{
-example(read10xVisium)
+example(SpatialExperiment)
 
 # rotateCoords(), mirrorCoords(), rotateObject(), and mirrorObject() return a
 # SpatialExperiment, potentially subsetted by sample.

--- a/man/SpatialExperiment-subset.Rd
+++ b/man/SpatialExperiment-subset.Rd
@@ -28,7 +28,7 @@ the remainder of the object.
 }
 
 \examples{
-example(read10xVisium)
+example(SpatialExperiment)
 
 dim(spe)
 

--- a/man/SpatialExperiment.Rd
+++ b/man/SpatialExperiment.Rd
@@ -98,9 +98,9 @@ this will be assumed from \code{sample_id} and \code{imageSources} instead.
 To combine multiple samples within a single object, see
 \code{\link{combine}}.
 
-For 10x Genomics Visium datasets, the function \code{\link{read10xVisium}}
-can be used to load data and create a \code{SpatialExperiment} object
-directly from Space Ranger output files.
+For 10x Genomics Visium datasets, the \code{\link[VisiumIO]{TENxVisiumList}} 
+and \code{\link[VisiumIO]{import}} functions can be used to load data into 
+a \code{SpatialExperiment} object directly from Space Ranger output files.
 }
 \examples{
 #########################################################
@@ -141,11 +141,19 @@ rd <- S4Vectors::DataFrame(
     sample_id = "foo"))
     
 #############################################################
-# Example 2: Spot-based ST (10x Visium) using 'read10xVisium'
+# Example 2: Spot-based ST (10x Visium) using 'VisiumIO'
 #############################################################
 
-# see ?read10xVisium for details
-example(read10xVisium)
+library(VisiumIO)
+dir <- list.dirs(system.file(
+  file.path("extdata", "10xVisium"),
+  package = "SpatialExperiment"), 
+  recursive = FALSE, full.names = TRUE)
+(spe <- import(TENxVisiumList(
+  sampleFolders = dir, 
+  sample_ids = basename(dir), 
+  processing = "raw", 
+  images = "lowres")))
 
 ##############################
 # Example 3: Molecule-based ST
@@ -205,8 +213,6 @@ y <- as.matrix(unclass(y))
 \code{?"\link{imgData-methods}"}
 
 \code{\link{SpatialImage}}
-
-\code{\link{read10xVisium}}
 }
 \author{
 Dario Righelli and Helena L. Crowell

--- a/man/SpatialExperiment.Rd
+++ b/man/SpatialExperiment.Rd
@@ -98,9 +98,9 @@ this will be assumed from \code{sample_id} and \code{imageSources} instead.
 To combine multiple samples within a single object, see
 \code{\link{combine}}.
 
-For 10x Genomics Visium datasets, the \code{\link[VisiumIO]{TENxVisiumList}} 
-and \code{\link[VisiumIO]{import}} functions can be used to load data into 
-a \code{SpatialExperiment} object directly from Space Ranger output files.
+For 10x Genomics Visium datasets, the \code{TENxVisiumList} and \code{import}
+functions from the \code{VisiumIO} package can be used to load data into a 
+\code{SpatialExperiment} object directly from Space Ranger output files.
 }
 \examples{
 #########################################################

--- a/man/imgData-methods.Rd
+++ b/man/imgData-methods.Rd
@@ -90,7 +90,7 @@ the image-related data stored inside a \code{SpatialExperiment}'s
 }
 }
 \examples{
-example(read10xVisium)
+example(SpatialExperiment)
 
 # 'SpatialImage' accession
 (spi <- getImg(spe))

--- a/tests/testthat/test_SpatialExperiment-assays.R
+++ b/tests/testthat/test_SpatialExperiment-assays.R
@@ -1,4 +1,4 @@
-example(read10xVisium, echo = FALSE)
+example(SpatialExperiment, echo = FALSE)
 
 test_that("molecules()/<- gets/sets assay(., 'molecules')", {
     tmp <- spe

--- a/tests/testthat/test_SpatialExperiment-cbind.R
+++ b/tests/testthat/test_SpatialExperiment-cbind.R
@@ -1,4 +1,4 @@
-example(read10xVisium, echo = FALSE)
+example(SpatialExperiment, echo = FALSE)
 
 test_that("duplicated sample_ids are made unique with a message", {
     expect_message(new <- cbind(spe, spe))

--- a/tests/testthat/test_SpatialExperiment-colData.R
+++ b/tests/testthat/test_SpatialExperiment-colData.R
@@ -1,4 +1,4 @@
-example(read10xVisium, echo = FALSE)
+example(SpatialExperiment, echo = FALSE)
 
 test_that("colData()<-NULL retains only sample_id", {
     tmp <- spe

--- a/tests/testthat/test_SpatialExperiment-methods.R
+++ b/tests/testthat/test_SpatialExperiment-methods.R
@@ -1,4 +1,4 @@
-example(read10xVisium, echo = FALSE)
+example(SpatialExperiment, echo = FALSE)
 
 test_that("spatialData()", {
     spd <- spatialData(spe)

--- a/tests/testthat/test_SpatialExperiment-rotate-mirror.R
+++ b/tests/testthat/test_SpatialExperiment-rotate-mirror.R
@@ -1,4 +1,4 @@
-example(read10xVisium, echo = FALSE)
+example(SpatialExperiment, echo = FALSE)
 
 test_that("rotateCoords, non-null sample_id", {
     #   Subset followed by identity rotation should be equivalent to simply

--- a/tests/testthat/test_SpatialExperiment-subset.R
+++ b/tests/testthat/test_SpatialExperiment-subset.R
@@ -1,4 +1,4 @@
-example(read10xVisium, echo = FALSE)
+example(SpatialExperiment, echo = FALSE)
 
 test_that("missing i/j retains all", {
     expect_identical(spe, spe[, ])

--- a/tests/testthat/test_SpatialExperiment.R
+++ b/tests/testthat/test_SpatialExperiment.R
@@ -1,4 +1,4 @@
-example(read10xVisium, echo = FALSE)
+example(SpatialExperiment, echo = FALSE)
 
 test_that("empty constructor", {
     spe <- SpatialExperiment()

--- a/tests/testthat/test_imgData-methods.R
+++ b/tests/testthat/test_imgData-methods.R
@@ -1,4 +1,4 @@
-example(read10xVisium, echo = FALSE)
+example(SpatialExperiment, echo = FALSE)
 
 test_that("getImg/imgRaster/Source w/o imgData return NULL", {
     x <- spe

--- a/vignettes/SpatialExperiment.Rmd
+++ b/vignettes/SpatialExperiment.Rmd
@@ -62,10 +62,9 @@ For demonstration of the general class structure, we load an example
 
 ```{r message = FALSE}
 library(SpatialExperiment)
-example(read10xVisium, echo = FALSE)
+example(SpatialExperiment, echo = FALSE)
 spe
 ```
-
 
 ## `spatialCoords`
 
@@ -323,15 +322,16 @@ rd <- S4Vectors::DataFrame(
     sample_id = "foo"))
 ```
 
-Alternatively, the `read10xVisium()` function facilitates the import of 
-*10x Genomics Visium* data to handle one or more samples organized in
-folders reflecting the default *Space Ranger* folder tree organization, 
-as illustrated below (where "raw/filtered" refers to either "raw" or 
-"filtered" to match the `data` argument). Note that the base directory 
-"outs/" from Space Ranger can either be included manually in the paths 
-provided in the `samples` argument, or can be ignored; if ignored, it will 
-be added automatically. The `.h5` files are used if `type = "HDF5"`. (Note 
-that `tissue_positions.csv` was renamed in Space Ranger v2.0.0.)
+Alternatively, `r BiocStyle::Biocpkg("VisiumIO")`'s `TENxVisium/List()` 
+functions facilitate the import of *10x Genomics Visium* data to handle one 
+or more samples organized in folders reflecting the default *Space Ranger* 
+folder tree organization, as illustrated below (where "raw/filtered" refers 
+to either "raw" or "filtered" to match the `data` argument). Note that the 
+base directory "outs/" from Space Ranger can either be included manually in the 
+paths provided in the `sampleFolders` argument, or can be ignored; if ignored, 
+it will be added automatically. (Note that `tissue_positions.csv` was renamed 
+in Space Ranger v2.0.0; the `tissuePattern` argument can be used to specify a
+pattern to match the tissue positions file.)
 
 ```{bash, eval = FALSE}
 sample
@@ -347,31 +347,20 @@ sample
  · · · | — tissue_positions.csv
 ```
 
-Using `read10xVisium()`, the above code to construct the same SPE is reduced to:
+Using `TENxVisiumList()`, the above code to construct the same SPE is reduced to:
 
 ```{r}
-dir <- system.file(
-    file.path("extdata", "10xVisium"),
-    package = "SpatialExperiment")
-
-sample_ids <- c("section1", "section2")
-samples <- file.path(dir, sample_ids, "outs")
-
-(spe10x <- read10xVisium(samples, sample_ids,
-    type = "sparse", data = "raw",
-    images = "lowres", load = FALSE))
+library(VisiumIO)
+dir <- list.dirs(system.file(
+    file.path("extdata", "10xVisium"), 
+    package = "SpatialExperiment"), 
+    recursive = FALSE, full.names = TRUE)
+(ids <- basename(dir))
+(vl <- TENxVisiumList(
+    sampleFolders = dir, sample_ids = ids, 
+    processing = "raw", image = "lowres"))
+(spe10x <- import(vl))
 ```
-
-Or alternatively, omitting the base directory `outs/` from Space Ranger:
-
-```{r}
-samples2 <- file.path(dir, sample_ids)
-
-(spe10x2 <- read10xVisium(samples2, sample_ids,
-    type = "sparse", data = "raw",
-    images = "lowres", load = FALSE))
-```
-
 
 ## Molecule-based
 


### PR DESCRIPTION
- We have been using `example(read10xVisium)` throughout function docs & unit tests; this has been changed to `example(SpatialExperiment)`, which now includes an example using `VisiumIO` to read in the example data in `inst/extdata`.
- Also added two `NEWS` entires; we have been behind versions 1.11 through 1.15 - it would be great if we can keep things more up to date in the future, even if it's just to add an entry saying "Bioc release 3.nm" prior to the next release when there haven't been any changes in the meantime.
- Also updated my personal email address & added ORCID iDs in the `DESCRIPTION` (could not find @Nick-Eagles; happy to add if you have one?)