### PR TITLE
allow additional image extensions 

### DIFF
--- a/R/Validity.R
+++ b/R/Validity.R
@@ -98,13 +98,18 @@ setValidity2("SpatialExperiment", .spe_validity)
 
 # SpatialImage validity --------------------------------------------------------
 
+.ALLOWED_FORMATS <- c("png", "jpg", "jpeg", "tif", "tiff")
+
 .path_validity <- function(x) {
+    
+    ext <- tools::file_ext(x) |> tolower()
+    
     is_valid <- all(c(
         length(x) == 1,
         is.character(x),
         file.exists(x),
-        # TODO: any other possible image formats? 
-        grepl("(\\.png|\\.jpg|\\.tif)$", x)))
+        ext %in% .ALLOWED_FORMATS
+    )) 
     
     if (!is_valid)
         stop("'path' should be a length-one character",


### PR DESCRIPTION
As first brought up here https://github.com/drighelli/SpatialExperiment/issues/159 , this PR makes a small change to the pattern used in the `.path_validity()` function to allows additional image file extensions and their capitalized variants. It increases the "long lines" note from `BiocCheck::BiocCheck()` from 25 to 26 but doesn't affect the check or test results otherwise.

```
    * NOTE: Consider shorter lines; 26 lines (1%) are > 80 characters
      long.
```

I tried to follow the contributor guidelines [here](https://github.com/drighelli/SpatialExperiment/wiki/Guidelines) as best as I could, please let me know if you'd like something changed.